### PR TITLE
Ensure only users can change their own profile

### DIFF
--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -4671,10 +4671,9 @@ func (bav *UtxoView) _connectUpdateProfile(
 		newProfileEntry = *existingProfileEntry
 
 		// Modifying a profile is only allowed if the transaction public key equals
-		// the profile public key or if the public key belongs to a paramUpdater.
+		// the profile public key
 		_, updaterIsParamUpdater := bav.Params.ParamUpdaterPublicKeys[MakePkMapKey(txn.PublicKey)]
-		if !reflect.DeepEqual(txn.PublicKey, existingProfileEntry.PublicKey) &&
-			!updaterIsParamUpdater {
+		if !reflect.DeepEqual(txn.PublicKey, existingProfileEntry.PublicKey) {
 
 			return 0, 0, nil, errors.Wrapf(
 				RuleErrorProfileModificationNotAuthorized,


### PR DESCRIPTION
It looks like there is a bug whereby a set of 6 private key holders can change the profile information of any user without the user's consent.