### PR TITLE
SOFT FORK: Today, BitClout joins the environmental movement.

### DIFF
--- a/lib/supply.go
+++ b/lib/supply.go
@@ -18,6 +18,7 @@ type PurchaseSupplyIntervalStart struct {
 const (
 	NanosPerUnit  = uint64(1000000000)
 	BlocksPerYear = uint32(12 * 24 * 365)
+	BlocksPerDay = uint32(12 * 24)
 	// Every 1M BitClout we sell causes the price to increase by a factor of 2.
 	TrancheSizeNanos = uint64(1000000000000000)
 	// When exchanging Bitcoin for BitClout, we don't allow transactions to create
@@ -40,23 +41,40 @@ const (
 var (
 	NaturalLogOfTwo = BigFloatLog(NewFloat().SetUint64(2))
 
+	DeflationBombBlockRewardAdjustmentBlockHeight = uint32(32060)
+
 	MiningSupplyIntervals = []*MiningSupplyIntervalStart{
 		{
 			StartBlockHeight: 0,
 			BlockRewardNanos: 1 * NanosPerUnit,
 		},
+		// Adjust the block reward as part of the deflation bomb to mark the BitClout
+		// dev community's commitment to a zero-waste, environmentally-friendly
+		// consensus mechanism. Do a smooth ramp in order to minimize issues with
+		// block mining times.
 		{
-			StartBlockHeight: 1 * BlocksPerYear,
-			BlockRewardNanos: 1 * NanosPerUnit / 2,
+			StartBlockHeight: DeflationBombBlockRewardAdjustmentBlockHeight,
+			BlockRewardNanos: NanosPerUnit * 3 / 4,
 		},
 		{
-			StartBlockHeight: 3 * BlocksPerYear,
+			StartBlockHeight: DeflationBombBlockRewardAdjustmentBlockHeight + BlocksPerDay,
+			BlockRewardNanos: NanosPerUnit / 2,
+		},
+		{
+			StartBlockHeight: DeflationBombBlockRewardAdjustmentBlockHeight + 2 * BlocksPerDay,
 			BlockRewardNanos: NanosPerUnit / 4,
 		},
 		{
-			StartBlockHeight: 7 * BlocksPerYear,
+			StartBlockHeight: DeflationBombBlockRewardAdjustmentBlockHeight + 3 * BlocksPerDay,
 			BlockRewardNanos: NanosPerUnit / 8,
 		},
+		{
+			StartBlockHeight: DeflationBombBlockRewardAdjustmentBlockHeight + 4 * BlocksPerDay,
+			BlockRewardNanos: NanosPerUnit / 10,
+		},
+		// Leave the block reward at .1 for the medium-term then tamp it down to zero.
+		// Note that the consensus mechanism will likely change to something more
+		// more energy-efficient before this point.
 		{
 			StartBlockHeight: 15 * BlocksPerYear,
 			BlockRewardNanos: NanosPerUnit / 20,

--- a/lib/supply_test.go
+++ b/lib/supply_test.go
@@ -31,7 +31,7 @@ func TestTotalMiningSupply(t *testing.T) {
 		numNanosMinedInInterval := blockRewardNanos * uint64(numBlocksInInterval)
 		totalMiningSupply += numNanosMinedInInterval
 	}
-	require.Equal(int64(509832*NanosPerUnit), int64(totalMiningSupply))
+	require.Equal(int64(276238800000000), int64(totalMiningSupply))
 }
 
 func TestCalcBlockReward(t *testing.T) {
@@ -42,18 +42,28 @@ func TestCalcBlockReward(t *testing.T) {
 
 	require.Equal(1*NanosPerUnit, CalcBlockRewardNanos(0))
 	require.Equal(1*NanosPerUnit, CalcBlockRewardNanos(1))
-	require.Equal(1*NanosPerUnit, CalcBlockRewardNanos(1*BlocksPerYear-1))
-	require.Equal(1*NanosPerUnit/2, CalcBlockRewardNanos(1*BlocksPerYear))
-	require.Equal(1*NanosPerUnit/2, CalcBlockRewardNanos(1*BlocksPerYear+1))
-	require.Equal(1*NanosPerUnit/2, CalcBlockRewardNanos(3*BlocksPerYear-1))
-	require.Equal(NanosPerUnit/4, CalcBlockRewardNanos(3*BlocksPerYear))
-	require.Equal(NanosPerUnit/4, CalcBlockRewardNanos(3*BlocksPerYear+1))
-	require.Equal(NanosPerUnit/4, CalcBlockRewardNanos(7*BlocksPerYear-1))
-	require.Equal(NanosPerUnit/8, CalcBlockRewardNanos(7*BlocksPerYear))
-	require.Equal(NanosPerUnit/8, CalcBlockRewardNanos(7*BlocksPerYear+1))
-	require.Equal(NanosPerUnit/8, CalcBlockRewardNanos(15*BlocksPerYear-1))
+
+	// .75
+	require.Equal(1*NanosPerUnit, CalcBlockRewardNanos(DeflationBombBlockRewardAdjustmentBlockHeight-1))
+	require.Equal(int64(float64(NanosPerUnit) * .75), int64(CalcBlockRewardNanos(DeflationBombBlockRewardAdjustmentBlockHeight)))
+	// .5
+	require.Equal(int64(float64(NanosPerUnit) * .75), int64(CalcBlockRewardNanos(DeflationBombBlockRewardAdjustmentBlockHeight + 288 - 1)))
+	require.Equal(int64(float64(NanosPerUnit) * .5), int64(CalcBlockRewardNanos(DeflationBombBlockRewardAdjustmentBlockHeight + 288)))
+	// .25
+	require.Equal(int64(float64(NanosPerUnit) * .5), int64(CalcBlockRewardNanos(DeflationBombBlockRewardAdjustmentBlockHeight + 2*288 - 1)))
+	require.Equal(int64(float64(NanosPerUnit) * .25), int64(CalcBlockRewardNanos(DeflationBombBlockRewardAdjustmentBlockHeight + 2*288)))
+	// .125
+	require.Equal(int64(float64(NanosPerUnit) * .25), int64(CalcBlockRewardNanos(DeflationBombBlockRewardAdjustmentBlockHeight + 3*288 - 1)))
+	require.Equal(int64(float64(NanosPerUnit) * .125), int64(CalcBlockRewardNanos(DeflationBombBlockRewardAdjustmentBlockHeight + 3*288)))
+	// .1
+	require.Equal(int64(float64(NanosPerUnit) * .125), int64(CalcBlockRewardNanos(DeflationBombBlockRewardAdjustmentBlockHeight + 4*288 - 1)))
+	require.Equal(int64(float64(NanosPerUnit) * .1), int64(CalcBlockRewardNanos(DeflationBombBlockRewardAdjustmentBlockHeight + 4*288)))
+
+	// .05
+	require.Equal(int64(1*NanosPerUnit/10), int64(CalcBlockRewardNanos(15*BlocksPerYear-1)))
 	require.Equal(NanosPerUnit/20, CalcBlockRewardNanos(15*BlocksPerYear))
 	require.Equal(NanosPerUnit/20, CalcBlockRewardNanos(15*BlocksPerYear+1))
+	// 0
 	require.Equal(NanosPerUnit/20, CalcBlockRewardNanos(32*BlocksPerYear-1))
 	require.Equal(uint64(0), CalcBlockRewardNanos(32*BlocksPerYear))
 	require.Equal(uint64(0), CalcBlockRewardNanos(32*BlocksPerYear+1))


### PR DESCRIPTION
I am proud to announce that the dev community has committed to moving to
a zero-waste consensus mechanism, and that it is taking a major step in
that direction with a new update.

Cryptocurrencies have gotten a lot of heat recently for being harmful to
the environment.

This is due in large part to "proof of work," a consensus mechanism that
burns CPU power to secure the network.

BitClout has relied on proof of work to get off the ground, but since
launching the dev community has already invested in consensus mechanisms
that allow BitClout to operate on orders of magnitude less power than
most existing proof of work cryptocurrencies.

Now, in a show of solidarity with the environmental movement, and to
take the first big step toward a zero-waste consensus mechanism,
BitClout is deploying a new update that reduces its power consumption by
a full order of magnitude.

BitClout is reducing the block reward, and thus the amount of
environmental waste its consensus mechanism incurs, by a factor of ten.

This was a difficult change to make, and it took the input of several
major node operators to deploy it safely.

We understand that miners in particular may not like this change;
however, there is now consensus around the decision to push the limits
of the BitClout chain toward conservation rather than allowing the
depletion of what are ultimately finite environmental resources.

There is still more work to do to move to a zero-waste consensus
mechanism without compromising on decentralization (e.g. full proof of
stake).

But the dev community is committed to getting there sooner rather than
later, and we hope this change shows just how committed we are.