### PR TITLE
Ln/fix update profile pubkey

### DIFF
--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -4779,7 +4779,7 @@ func (bav *UtxoView) _connectUpdateProfile(
 		// In this case we need to set all the fields using what was passed
 		// into the transaction.
 		newProfileEntry = ProfileEntry{
-			PublicKey:   txn.PublicKey,
+			PublicKey:   profilePublicKey,
 			Username:    txMeta.NewUsername,
 			Description: txMeta.NewDescription,
 			ProfilePic:  txMeta.NewProfilePic,

--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -4778,8 +4778,16 @@ func (bav *UtxoView) _connectUpdateProfile(
 
 		// In this case we need to set all the fields using what was passed
 		// into the transaction.
+
+		// If below block height, user transaction public key.
+		// If above block height, use ProfilePublicKey if available.
+		profileEntryPublicKey := txn.PublicKey
+		if blockHeight > ParamUpdaterProfileUpdateFixBlockHeight {
+			profileEntryPublicKey = profilePublicKey
+		}
+
 		newProfileEntry = ProfileEntry{
-			PublicKey:   profilePublicKey,
+			PublicKey:   profileEntryPublicKey,
 			Username:    txMeta.NewUsername,
 			Description: txMeta.NewDescription,
 			ProfilePic:  txMeta.NewProfilePic,

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -90,6 +90,8 @@ var (
 	// BitCloutFounderRewardBlockHeight defines a block height where the protocol switches from
 	// paying the founder reward in the founder's own creator coin to paying in BitClout instead.
 	BitCloutFounderRewardBlockHeight = uint32(21869)
+
+	ParamUpdaterProfileUpdateFixBlockHeight = uint32(38685)
 )
 
 func (nt NetworkType) String() string {

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -91,7 +91,9 @@ var (
 	// paying the founder reward in the founder's own creator coin to paying in BitClout instead.
 	BitCloutFounderRewardBlockHeight = uint32(21869)
 
-	ParamUpdaterProfileUpdateFixBlockHeight = uint32(38685)
+	// ParamUpdaterProfileUpdateFixBlockHeights defines a block height after which the protocol uses the update profile
+	// txMeta's ProfilePublicKey when the Param Updater is creating a profile for ProfilePublicKey.
+	ParamUpdaterProfileUpdateFixBlockHeight = uint32(39713)
 )
 
 func (nt NetworkType) String() string {

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -91,7 +91,7 @@ var (
 	// paying the founder reward in the founder's own creator coin to paying in BitClout instead.
 	BitCloutFounderRewardBlockHeight = uint32(21869)
 
-	// ParamUpdaterProfileUpdateFixBlockHeights defines a block height after which the protocol uses the update profile
+	// ParamUpdaterProfileUpdateFixBlockHeight defines a block height after which the protocol uses the update profile
 	// txMeta's ProfilePublicKey when the Param Updater is creating a profile for ProfilePublicKey.
 	ParamUpdaterProfileUpdateFixBlockHeight = uint32(39713)
 )


### PR DESCRIPTION
- Use the txMeta's ProfilePublicKey if provided when creating a profile for a new public key as the Param Updater.