### PR TITLE
omit TxIndexMetadata in json if empty for TransactionMetadata

### DIFF
--- a/lib/db_utils.go
+++ b/lib/db_utils.go
@@ -3026,16 +3026,16 @@ type TransactionMetadata struct {
 	// when looking up output amounts
 	TxnOutputs []*BitCloutOutput
 
-	BasicTransferTxindexMetadata       *BasicTransferTxindexMetadata
-	BitcoinExchangeTxindexMetadata     *BitcoinExchangeTxindexMetadata
-	CreatorCoinTxindexMetadata         *CreatorCoinTxindexMetadata
-	CreatorCoinTransferTxindexMetadata *CreatorCoinTransferTxindexMetadata
-	UpdateProfileTxindexMetadata       *UpdateProfileTxindexMetadata
-	SubmitPostTxindexMetadata          *SubmitPostTxindexMetadata
-	LikeTxindexMetadata                *LikeTxindexMetadata
-	FollowTxindexMetadata              *FollowTxindexMetadata
-	PrivateMessageTxindexMetadata      *PrivateMessageTxindexMetadata
-	SwapIdentityTxindexMetadata        *SwapIdentityTxindexMetadata
+	BasicTransferTxindexMetadata       *BasicTransferTxindexMetadata `json:",omitempty"`
+	BitcoinExchangeTxindexMetadata     *BitcoinExchangeTxindexMetadata `json:",omitempty"`
+	CreatorCoinTxindexMetadata         *CreatorCoinTxindexMetadata `json:",omitempty"`
+	CreatorCoinTransferTxindexMetadata *CreatorCoinTransferTxindexMetadata `json:",omitempty"`
+	UpdateProfileTxindexMetadata       *UpdateProfileTxindexMetadata `json:",omitempty"`
+	SubmitPostTxindexMetadata          *SubmitPostTxindexMetadata `json:",omitempty"`
+	LikeTxindexMetadata                *LikeTxindexMetadata `json:",omitempty"`
+	FollowTxindexMetadata              *FollowTxindexMetadata `json:",omitempty"`
+	PrivateMessageTxindexMetadata      *PrivateMessageTxindexMetadata `json:",omitempty"`
+	SwapIdentityTxindexMetadata        *SwapIdentityTxindexMetadata `json:",omitempty"`
 }
 
 func DbGetTxindexTransactionRefByTxIDWithTxn(txn *badger.Txn, txID *BlockHash) *TransactionMetadata {


### PR DESCRIPTION
This will reduce the payload for `/api/v0/get-notifications` and `/api/v1/transaction-info` by excluding the keys for transaction metadata attributes that don't exist. E.g. we only expect to see basic transfer and follow metadata in a follow transaction, so we shouldn't include the keys for other transaction metadata types, such as `LikeTxindexMetadata`