### PR TITLE
Add shared secret encryption/decryption

### DIFF
--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -164,6 +164,10 @@ type MessageEntry struct {
 	TstampNanos uint64
 
 	isDeleted bool
+
+	// If this field is set to true, it indicates that message was
+	// encrypted using shared secret
+	V2 bool
 }
 
 // Entry for a public key forbidden from signing blocks.
@@ -3939,6 +3943,17 @@ func (bav *UtxoView) _connectPrivateMessage(
 		RecipientPublicKey: txMeta.RecipientPublicKey,
 		EncryptedText:      txMeta.EncryptedText,
 		TstampNanos:        txMeta.TimestampNanos,
+		V2: 				false,
+	}
+
+
+	//Check if message is encrypted with shared secret
+	extraV2, hasExtraV2 := txn.ExtraData["V2"]
+	if hasExtraV2 {
+		isV2,_ := Uvarint(extraV2)
+		if isV2 == 1{
+			messageEntry.V2 = true
+		}
 	}
 
 	// Set the mappings in our in-memory map for the MessageEntry.

--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -167,7 +167,7 @@ type MessageEntry struct {
 
 	// If this field is set to true, it indicates that message was
 	// encrypted using shared secret
-	V2 bool
+	Version uint8
 }
 
 // Entry for a public key forbidden from signing blocks.
@@ -3943,17 +3943,15 @@ func (bav *UtxoView) _connectPrivateMessage(
 		RecipientPublicKey: txMeta.RecipientPublicKey,
 		EncryptedText:      txMeta.EncryptedText,
 		TstampNanos:        txMeta.TimestampNanos,
-		V2: 				false,
+		Version:            1,
 	}
 
 
 	//Check if message is encrypted with shared secret
-	extraV2, hasExtraV2 := txn.ExtraData["V2"]
-	if hasExtraV2 {
-		isV2,_ := Uvarint(extraV2)
-		if isV2 == 1{
-			messageEntry.V2 = true
-		}
+	extraV, hasExtraV := txn.ExtraData["V"]
+	if hasExtraV {
+		Version,_ := Uvarint(extraV)
+		messageEntry.Version = uint8(Version)
 	}
 
 	// Set the mappings in our in-memory map for the MessageEntry.

--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -165,8 +165,9 @@ type MessageEntry struct {
 
 	isDeleted bool
 
-	// If this field is set to true, it indicates that message was
-	// encrypted using shared secret
+	// Indicates message encryption method
+	// Version = 2 : message encrypted using shared secret
+	// Version = 1 : message encrypted using public key
 	Version uint8
 }
 

--- a/lib/blockchain.go
+++ b/lib/blockchain.go
@@ -2418,12 +2418,11 @@ func (bc *Blockchain) CreatePrivateMessageTxn(
 			EncryptedText:      encryptedMessageBytes,
 			TimestampNanos:     tstampNanos,
 		},
+		ExtraData: messageExtraData,
 
 		// We wait to compute the signature until we've added all the
 		// inputs and change.
 	}
-
-	txn.ExtraData = messageExtraData
 
 	totalInput, spendAmount, changeAmount, fees, err :=
 		bc.AddInputsAndChangeToTransaction(txn, minFeeRateNanosPerKB, mempool)

--- a/lib/db_utils.go
+++ b/lib/db_utils.go
@@ -507,7 +507,7 @@ func DbPutMessageEntryWithTxn(
 		RecipientPublicKey: messageEntry.RecipientPublicKey,
 		EncryptedText:      messageEntry.EncryptedText,
 		TstampNanos:        messageEntry.TstampNanos,
-		V2:					messageEntry.V2,
+		Version:            messageEntry.Version,
 	}
 
 	messageDataBuf := bytes.NewBuffer([]byte{})

--- a/lib/db_utils.go
+++ b/lib/db_utils.go
@@ -388,7 +388,7 @@ func _enumerateKeysForPrefix(db *badger.DB, dbPrefix []byte) (_keysFound [][]byt
 		return nil
 	})
 	if dbErr != nil {
-		glog.Errorf("_enumerateKeysForPrefix: Problem fetching keys and vlaues from db: %v", dbErr)
+		glog.Errorf("_enumerateKeysForPrefix: Problem fetching keys and values from db: %v", dbErr)
 		return nil, nil
 	}
 
@@ -429,7 +429,7 @@ func _enumerateLimitedKeysReversedForPrefix(db *badger.DB, dbPrefix []byte, limi
 		return err
 	})
 	if dbErr != nil {
-		glog.Errorf("_enumerateKeysForPrefix: Problem fetching keys and vlaues from db: %v", dbErr)
+		glog.Errorf("_enumerateKeysForPrefix: Problem fetching keys and values from db: %v", dbErr)
 		return nil, nil
 	}
 
@@ -507,6 +507,7 @@ func DbPutMessageEntryWithTxn(
 		RecipientPublicKey: messageEntry.RecipientPublicKey,
 		EncryptedText:      messageEntry.EncryptedText,
 		TstampNanos:        messageEntry.TstampNanos,
+		V2:					messageEntry.V2,
 	}
 
 	messageDataBuf := bytes.NewBuffer([]byte{})


### PR DESCRIPTION
No change to txn metadata. Information about the encryption scheme (V2) passed through ExtraData. Added V2 field to MessageEntry to differentiate between shared secret and legacy public key encryptions.