### PR TITLE
remove underscore as mention terminator

### DIFF
--- a/lib/mempool.go
+++ b/lib/mempool.go
@@ -1509,7 +1509,7 @@ func ComputeTransactionMetadata(txn *MsgBitCloutTxn, utxoView *UtxoView, blockHa
 			glog.Tracef("UpdateTxindex: Error parsing post body for @ mentions: "+
 				"%v %v", string(realTxMeta.Body), err)
 		} else {
-			terminators := []rune(" ,.\n&*()-_+~'\"[]{}")
+			terminators := []rune(" ,.\n&*()-+~'\"[]{}")
 			dollarTagsFound := mention.GetTagsAsUniqueStrings('$', bodyObj.Body, terminators...)
 			atTagsFound := mention.GetTagsAsUniqueStrings('@', bodyObj.Body, terminators...)
 			tagsFound := append(dollarTagsFound, atTagsFound...)


### PR DESCRIPTION
Since underscore `_` is a valid character in usernames, we cannot use it as a terminator for mentions. Current users with underscores in their handles are not receiving notifications.