### PR TITLE
Fix TXIndex shutdown crashes

### DIFF
--- a/cmd/node.go
+++ b/cmd/node.go
@@ -170,7 +170,10 @@ func (node *Node) Start() {
 func (node *Node) Stop() {
 	node.Server.Stop()
 	node.chainDB.Close()
-	node.TXIndex.Stop()
+
+	if node.TXIndex != nil {
+		node.TXIndex.Stop()
+	}
 }
 
 func validateParams(params *lib.BitCloutParams) {


### PR DESCRIPTION
When SIGTERM'ing the node, memory access segfaults were occurring in `txindex.go`.

If TXIndex was disabled, the reference was being accessed regardless, causing a crash.

If TXIndex was enabled, the Update goroutine was not being stopped before the database was closed.

This fixes both issues. I'm new to Go so apologize if this patch is doing something non-idiomatic or wrong. SIGTERM now seems to shut down properly. 