### PR TITLE
Fix profile vulnerability

### DIFF
--- a/lib/block_view_test.go
+++ b/lib/block_view_test.go
@@ -3082,6 +3082,7 @@ const (
 func TestUpdateProfile(t *testing.T) {
 	// For testing purposes, we set the fix block height to be 0 for the ParamUpdaterProfileUpdateFixBlockHeight.
 	ParamUpdaterProfileUpdateFixBlockHeight = 0
+	UpdateProfileFixBlockHeight = 0
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -3337,6 +3338,24 @@ func TestUpdateProfile(t *testing.T) {
 			false /*isHidden*/)
 		require.Error(err)
 		require.Contains(err.Error(), RuleErrorProfileBadPublicKey)
+	}
+
+	// Profile public key that is not authorized should fail.
+	{
+		_, _, _, err = _updateProfile(
+			t, chain, db, params,
+			1,             /*feeRateNanosPerKB*/
+			m0Pub,         /*updaterPkBase58Check*/
+			m0Priv,        /*updaterPrivBase58Check*/
+			m1PkBytes,     /*profilePubKey*/
+			"m0",          /*newUsername*/
+			"i am the m0", /*newDescription*/
+			shortPic,      /*newProfilePic*/
+			10*100,        /*newCreatorBasisPoints*/
+			1.25*100*100,  /*newStakeMultipleBasisPoints*/
+			false /*isHidden*/)
+		require.Error(err)
+		require.Contains(err.Error(), RuleErrorProfilePubKeyNotAuthorized)
 	}
 
 	// A simple registration should succeed
@@ -3616,7 +3635,7 @@ func TestUpdateProfile(t *testing.T) {
 			1.25*100*100,     /*newStakeMultipleBasisPoints*/
 			false /*isHidden*/)
 		require.Error(err)
-		require.Contains(err.Error(), RuleErrorProfileModificationNotAuthorized)
+		require.Contains(err.Error(), RuleErrorProfilePubKeyNotAuthorized)
 	}
 
 	// ParamUpdater updating another user's profile should succeed.

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -104,6 +104,10 @@ var (
 	// ParamUpdaterProfileUpdateFixBlockHeight defines a block height after which the protocol uses the update profile
 	// txMeta's ProfilePublicKey when the Param Updater is creating a profile for ProfilePublicKey.
 	ParamUpdaterProfileUpdateFixBlockHeight = uint32(39713)
+
+	// UpdateProfileFixBlockHeight defines the height at which a patch was added to prevent user from
+	// updating the profile entry for arbitrary public keys that do not have existing profile entries.
+	UpdateProfileFixBlockHeight = uint32(46165)
 )
 
 func (nt NetworkType) String() string {

--- a/lib/errors.go
+++ b/lib/errors.go
@@ -111,6 +111,7 @@ const (
 	RuleErrorCreateProfileTxnOutputExceedsInput RuleError = "RuleErrorCreateProfileTxnOutputExceedsInput"
 	RuleErrorProfilePublicKeySize               RuleError = "RuleErrorProfilePublicKeySize"
 	RuleErrorProfileBadPublicKey                RuleError = "RuleErrorProfileBadPublicKey"
+	RuleErrorProfilePubKeyNotAuthorized         RuleError = "RuleErrorProfilePubKeyNotAuthorized"
 	RuleErrorProfileModificationNotAuthorized   RuleError = "RuleErrorProfileModificationNotAuthorized"
 	RuleErrorProfileUsernameCannotContainZeros  RuleError = "RuleErrorProfileUsernameCannotContainZeros"
 


### PR DESCRIPTION
Add check to ensure that either (1) profilePublicKey is owned by the txn signer or (2) the signer is a param updater.