### PR TITLE
Add UtxoOperations from _connect* funcs to the BasicTransferTxindexMe…

### DIFF
--- a/lib/db_utils.go
+++ b/lib/db_utils.go
@@ -3117,6 +3117,7 @@ type BasicTransferTxindexMetadata struct {
 	TotalOutputNanos uint64
 	FeeNanos         uint64
 	UtxoOpsDump      string
+	UtxoOps []*UtxoOperation
 }
 type BitcoinExchangeTxindexMetadata struct {
 	BitcoinSpendAddress string


### PR DESCRIPTION
…tadata

This is needed in order to allow Rosetta to compute implicit inputs.