### PR TITLE
Properly shutdown block producer

### DIFF
--- a/lib/server.go
+++ b/lib/server.go
@@ -1733,6 +1733,11 @@ func (srv *Server) Stop() {
 		srv.mempool.Stop()
 	}
 
+	// Stop the block producer
+	if srv.blockProducer != nil {
+		srv.blockProducer.Stop()
+	}
+
 	// This will signal any goroutines to quit. Note that enqueing this after stopping
 	// the ConnectionManager seems like it should cause the Server to process any remaining
 	// messages before calling waitGroup.Done(), which seems like a good thing.


### PR DESCRIPTION
I'm not sure if this is a regression, but it looks like the block producer is now not being shut down on Stop(). (Was this always broken? I had a previous PR which dealt with graceful shutdowns for it, so maybe I was fooling myself that it was being shut down?)