### PR TITLE
Fix testnet seed balances

### DIFF
--- a/lib/blockchain_test.go
+++ b/lib/blockchain_test.go
@@ -507,7 +507,7 @@ func TestSeedBalancesTest(t *testing.T) {
 
 	chain, params, db := NewTestBlockchain()
 	for _, seedBalance := range params.SeedBalances {
-		require.Equal(int64(1), int64(GetUtxoNumEntries(db)))
+		require.Equal(int64(482), int64(GetUtxoNumEntries(db)))
 		foundUtxos, err := chain.GetSpendableUtxosForPublicKey(seedBalance.PublicKey, nil, nil)
 		require.NoError(err)
 		require.Equal(int64(1), int64(len(foundUtxos)))

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -733,7 +733,8 @@ var BitCloutTestnetParams = BitCloutParams{
 	SeedTxns: TestSeedTxns,
 
 	// Set some seed balances if desired
-	SeedBalances: TestSeedBalances,
+	// Note: For now these must be the same as mainnet because GenesisBlock is the same
+	SeedBalances: SeedBalances,
 
 	// Just charge one basis point on creator coin trades for now.
 	CreatorCoinTradeFeeBasisPoints: 1,

--- a/lib/seed_txns.go
+++ b/lib/seed_txns.go
@@ -1962,12 +1962,6 @@ var (
 			AmountNanos: uint64(15600),
 		},
 	}
-	TestSeedBalances = []*BitCloutOutput{
-		{
-			PublicKey:   MustBase58CheckDecode("BC1YLjBxKjyopwRqZQkZaQKZbzq1peYv1F8rU2aNBQFe8eJR2eXR8B9"),
-			AmountNanos: uint64(2000000 * NanosPerUnit),
-		},
-	}
 	// In early blocks there was a bug that allowed users to claim usernames that
 	// weren't actually available. This map defines exceptions for these cases that
 	// assign a new username to the profile. It maps transaction hashes to new


### PR DESCRIPTION
The `GenesisBlock` contains `SeedBalances` and is not parameterized to accept `TestSeedBalances`. This was breaking rosetta-cli data checks.