### PR TITLE
Set blockheight to trigger NFT transfers + burns.

### DIFF
--- a/lib/constants.go
+++ b/lib/constants.go
@@ -121,7 +121,8 @@ var (
 
 	// NFTTransfersBlockHeight defines the height at which NFT transfer txns, accept NFT
 	// transfer txns, and NFT burn txns will be accepted.
-	NFTTransferOrBurnBlockHeight = uint32(100000)
+	// Triggers: 12PM PT on 9/15/2021
+	NFTTransferOrBurnBlockHeight = uint32(59203)
 )
 
 func (nt NetworkType) String() string {

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -122,7 +122,7 @@ var (
 	// NFTTransfersBlockHeight defines the height at which NFT transfer txns, accept NFT
 	// transfer txns, and NFT burn txns will be accepted.
 	// Triggers: 12PM PT on 9/15/2021
-	NFTTransferOrBurnBlockHeight = uint32(59203)
+	NFTTransferOrBurnBlockHeight = uint32(60743)
 )
 
 func (nt NetworkType) String() string {


### PR DESCRIPTION
New blockheight computed as, "time until Wednesday, 9/15/2021 at Noon PT divided by 5min per block."  Current blockheight is 59,057 with ~8430 minutes until Wednesday Noon. Therefore the trigger blockheight is set to  60,743 (59,057+1686).